### PR TITLE
Updated Gmarker.class.php to use cURL rather than file_get_contents

### DIFF
--- a/core/components/gmarker/model/gmarker/Gmarker.class.php
+++ b/core/components/gmarker/model/gmarker/Gmarker.class.php
@@ -277,8 +277,19 @@ class Gmarker {
 		}
 
 		$this->modx->log(xPDO::LOG_LEVEL_DEBUG, "[Gmarker] query URL: $url");
+		
+		$ch = curl_init();
+	 
+	    	curl_setopt($ch, CURLOPT_URL, $url); 
+	    	curl_setopt($ch, CURLOPT_HEADER, 0);
+	    	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+	    	curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 
-		return file_get_contents($url);
+	    	$curlOutput = curl_exec($ch);
+	 
+	    	curl_close($ch);
+
+		return $curlOutput;
 	}
 
 	/**


### PR DESCRIPTION
Updated Gmarker.class.php to use cURL rather than file_get_contents() within the query_api() function. This should be a little faster and compatible with more hosting environments.
