### PR TITLE
Make the snippet work with german locale

### DIFF
--- a/core/components/gmarker/elements/snippets/snippet.Gmarker.php
+++ b/core/components/gmarker/elements/snippets/snippet.Gmarker.php
@@ -386,8 +386,8 @@ if($checkbox == 1 && $group != null) {
 $json = $Gmarker->lookup($goog, $secure);
 
 // Pull the coordinates out of the response
-$props['lat'] = $Gmarker->get('location.lat');
-$props['lng'] = $Gmarker->get('location.lng');
+$props['lat'] = number_format($Gmarker->get('location.lat'), 8);
+$props['lng'] = number_format($Gmarker->get('location.lng'), 8);
 
 // Add some styling to hide the info-window shadows
 $props['hide_shadow'] = '';


### PR DESCRIPTION
In german locale the point and comma are swapped and floats are automatic shown with comma by parseChunk if passed as float and not as string. Same changes should be made to Gmap.
